### PR TITLE
seed: Add examples on how to run a seed node

### DIFF
--- a/seed/README.md
+++ b/seed/README.md
@@ -48,8 +48,7 @@ To see the seed dashboard, point your browser to http://127.0.0.1:8888.
       track-urns        A set of URNs to track
       track-peers       A set of peers to track
 
-    EXAMPLES
-
+    Examples:
     Start a seed node that tracks and replicates specific peers
 
         $ radicle-seed-node --root ~/.radicle-seed track-peers \

--- a/seed/README.md
+++ b/seed/README.md
@@ -24,14 +24,18 @@ To see the seed dashboard, point your browser to http://127.0.0.1:8888.
 
 ## Usage
 
-    radicle-seed-node [options]
+    radicle-seed-node [[--track-peer <track-peer>] | [--track-urn <track-urn>]]
+                      [--peer-listen <peer-listen>] [--http-listen <http-listen>]
+                      [--log <log>] [--root <root>] [--name <name>]
+                      [--description <description>] [--public-addr <public-addr>]
 
-    Radicle Seed. To run the node a PKCS8 encoded secret key must be provided
-    as STDIN.
+    To run the seed node, a PKCS8 encoded secret key **must always** be
+    provided in STDIN.
 
-    Options:
-      --track-peers     track the specified peers only
-      --track-urns      track the specified URNs only
+    OPTIONS
+
+      --track-peer      track the specified peer only
+      --track-urn       track the specified URN only
       --peer-listen     listen on the following address for peer connections
       --http-listen     listen on the following address for HTTP connections
                         (default: 127.0.0.1:8888)
@@ -42,3 +46,36 @@ To see the seed dashboard, point your browser to http://127.0.0.1:8888.
       --public-addr     public address of this seed node, eg.
                         'seedling.radicle.xyz:12345'
       --help            display usage information
+
+
+    EXAMPLES
+
+    Start a seed node that tracks and replicates specific peers
+
+        $ radicle-seed-node --root ~/.radicle-seed \
+                            --track-peer hyymwdkgymeupidbgwfb16wp5fg1ojz3ias8c8ijtdeecjo6yxtw3g \
+                            --track-peer hydijmyip398ihqejgpouwhfszdmd45dkh7xwd9ewtjmzwp9tb855a \
+                            --track-peer hybra8u45w7ahr195sqcw136twqrjg3nknbzxhyd1pncwsr3pwnkc1 \
+                            < ~/.radicle-seed/secret.key
+
+        INFO radicle_seed: Initializing tracker with 3 peers..
+
+    Start a seed node that tracks and replicates specific URNs
+
+        $ radicle-seed-node --root ~/.radicle-seed \
+                            --track-urn rad:git:hwd1yrebfxd5fu79qh4zejg4kf1xohfg54iqyssf7guds6cp6hkug4iqsmc \
+                            --track-urn rad:git:hwd1yref9i4h9certox1dpb5nfruk9gfyyjnjodg63oqak7d3pa6bpy6bmc \
+                            < ~/.radicle-seed/secret.key
+
+        Nov 11 18:03:25.650  INFO radicle_seed: Initializing tracker with 2 URNs..
+
+    Start a seed node that tracks and replicates any peer that connects. All
+    URNs that any peer gossips will be replicated.
+
+        $ radicle-seed-node --root ~/.radicle-seed \
+                            --public-addr "superseed.monadic.xyz:4444" \
+                            --name "Radicle seed node" \
+                            --description "<p>The dashboard for Radicle's first public seed node.</p>" \
+                            < ~/.radicle-seed/secret.key
+
+        Nov 11 18:08:13.660  INFO radicle_seed: Initializing tracker to track everything..

--- a/seed/README.md
+++ b/seed/README.md
@@ -24,18 +24,15 @@ To see the seed dashboard, point your browser to http://127.0.0.1:8888.
 
 ## Usage
 
-    radicle-seed-node [[--track-peer <track-peer>] | [--track-urn <track-urn>]]
-                      [--peer-listen <peer-listen>] [--http-listen <http-listen>]
+    radicle-seed-node [--peer-listen <peer-listen>] [--http-listen <http-listen>]
                       [--log <log>] [--root <root>] [--name <name>]
                       [--description <description>] [--public-addr <public-addr>]
+                      [<command>] [<args>]
 
     To run the seed node, a PKCS8 encoded secret key **must always** be
     provided in STDIN.
 
-    OPTIONS
-
-      --track-peer      track the specified peer only
-      --track-urn       track the specified URN only
+    Options:
       --peer-listen     listen on the following address for peer connections
       --http-listen     listen on the following address for HTTP connections
                         (default: 127.0.0.1:8888)
@@ -47,24 +44,27 @@ To see the seed dashboard, point your browser to http://127.0.0.1:8888.
                         'seedling.radicle.xyz:12345'
       --help            display usage information
 
+    Commands:
+      track-urns        A set of URNs to track
+      track-peers       A set of peers to track
 
     EXAMPLES
 
     Start a seed node that tracks and replicates specific peers
 
-        $ radicle-seed-node --root ~/.radicle-seed \
-                            --track-peer hyymwdkgymeupidbgwfb16wp5fg1ojz3ias8c8ijtdeecjo6yxtw3g \
-                            --track-peer hydijmyip398ihqejgpouwhfszdmd45dkh7xwd9ewtjmzwp9tb855a \
-                            --track-peer hybra8u45w7ahr195sqcw136twqrjg3nknbzxhyd1pncwsr3pwnkc1 \
+        $ radicle-seed-node --root ~/.radicle-seed track-peers \
+                            --peer hyymwdkgymeupidbgwfb16wp5fg1ojz3ias8c8ijtdeecjo6yxtw3g \
+                            --peer hydijmyip398ihqejgpouwhfszdmd45dkh7xwd9ewtjmzwp9tb855a \
+                            --peer hybra8u45w7ahr195sqcw136twqrjg3nknbzxhyd1pncwsr3pwnkc1 \
                             < ~/.radicle-seed/secret.key
 
         INFO radicle_seed: Initializing tracker with 3 peers..
 
     Start a seed node that tracks and replicates specific URNs
 
-        $ radicle-seed-node --root ~/.radicle-seed \
-                            --track-urn rad:git:hwd1yrebfxd5fu79qh4zejg4kf1xohfg54iqyssf7guds6cp6hkug4iqsmc \
-                            --track-urn rad:git:hwd1yref9i4h9certox1dpb5nfruk9gfyyjnjodg63oqak7d3pa6bpy6bmc \
+        $ radicle-seed-node --root ~/.radicle-seed track-urns \
+                            --urn rad:git:hwd1yrebfxd5fu79qh4zejg4kf1xohfg54iqyssf7guds6cp6hkug4iqsmc \
+                            --urn rad:git:hwd1yref9i4h9certox1dpb5nfruk9gfyyjnjodg63oqak7d3pa6bpy6bmc \
                             < ~/.radicle-seed/secret.key
 
         Nov 11 18:03:25.650  INFO radicle_seed: Initializing tracker with 2 URNs..

--- a/seed/src/main.rs
+++ b/seed/src/main.rs
@@ -29,12 +29,12 @@ use argh::FromArgs;
 /// Radicle Seed.
 pub struct Options {
     /// track the specified peer only
-    #[argh(option)]
-    pub track_peer: Vec<PeerId>,
+    #[argh(option, long = "track-peer")]
+    pub track_peers: Vec<PeerId>,
 
     /// track the specified URN only
-    #[argh(option)]
-    pub track_urn: Vec<RadUrn>,
+    #[argh(option, long = "track-urn")]
+    pub track_urns: Vec<RadUrn>,
 
     /// listen on the following address for peer connections
     #[argh(option)]
@@ -85,7 +85,7 @@ async fn main() {
         Err(err) => panic!("invalid key was supplied to stdin: {}", err),
     };
 
-    if !opts.track_peer.is_empty() && !opts.track_urn.is_empty() {
+    if !opts.track_peers.is_empty() && !opts.track_urns.is_empty() {
         println!("--track-peer and --track-urn are mutually exclusive options!");
         process::exit(1);
     }
@@ -95,10 +95,10 @@ async fn main() {
             .peer_listen
             .unwrap_or(NodeConfig::default().listen_addr),
         root: opts.root,
-        mode: if !opts.track_peer.is_empty() {
-            Mode::TrackPeers(opts.track_peer.into_iter().collect())
-        } else if !opts.track_urn.is_empty() {
-            Mode::TrackUrns(opts.track_urn.into_iter().collect())
+        mode: if !opts.track_peers.is_empty() {
+            Mode::TrackPeers(opts.track_peers.into_iter().collect())
+        } else if !opts.track_urns.is_empty() {
+            Mode::TrackUrns(opts.track_urns.into_iter().collect())
         } else {
             Mode::TrackEverything
         },

--- a/seed/src/main.rs
+++ b/seed/src/main.rs
@@ -28,13 +28,13 @@ use argh::FromArgs;
 #[derive(FromArgs)]
 /// Radicle Seed.
 pub struct Options {
-    /// track the specified peers only
+    /// track the specified peer only
     #[argh(option)]
-    pub track_peers: Vec<PeerId>,
+    pub track_peer: Vec<PeerId>,
 
-    /// track the specified URNs only
+    /// track the specified URN only
     #[argh(option)]
-    pub track_urns: Vec<RadUrn>,
+    pub track_urn: Vec<RadUrn>,
 
     /// listen on the following address for peer connections
     #[argh(option)]
@@ -90,10 +90,10 @@ async fn main() {
             .peer_listen
             .unwrap_or(NodeConfig::default().listen_addr),
         root: opts.root,
-        mode: if !opts.track_peers.is_empty() {
-            Mode::TrackPeers(opts.track_peers.into_iter().collect())
-        } else if !opts.track_urns.is_empty() {
-            Mode::TrackUrns(opts.track_urns.into_iter().collect())
+        mode: if !opts.track_peer.is_empty() {
+            Mode::TrackPeers(opts.track_peer.into_iter().collect())
+        } else if !opts.track_urn.is_empty() {
+            Mode::TrackUrns(opts.track_urn.into_iter().collect())
         } else {
             Mode::TrackEverything
         },

--- a/seed/src/main.rs
+++ b/seed/src/main.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use std::{net, path::PathBuf};
+use std::{net, path::PathBuf, process};
 
 use tracing_subscriber::FmtSubscriber;
 
@@ -84,6 +84,11 @@ async fn main() {
         Ok(signer) => signer,
         Err(err) => panic!("invalid key was supplied to stdin: {}", err),
     };
+
+    if !opts.track_peer.is_empty() && !opts.track_urn.is_empty() {
+        println!("--track-peer and --track-urn are mutually exclusive options!");
+        process::exit(1);
+    }
 
     let config = NodeConfig {
         listen_addr: opts

--- a/seed/src/main.rs
+++ b/seed/src/main.rs
@@ -47,7 +47,7 @@ pub struct Urns {
 #[argh(subcommand)]
 pub enum Track {
     Urns(Urns),
-    Peers(Peers)
+    Peers(Peers),
 }
 
 #[derive(FromArgs)]
@@ -115,7 +115,7 @@ async fn main() {
             Some(Track::Peers(Peers { peers })) => Mode::TrackPeers(peers.into_iter().collect()),
             Some(Track::Urns(Urns { urns })) => Mode::TrackUrns(urns.into_iter().collect()),
             None => Mode::TrackEverything,
-        }
+        },
     };
     let node = Node::new(config, signer).unwrap();
     let handle = node.handle();


### PR DESCRIPTION
Renamed the options to singular, because it was not possible to supply
an array of multiple values to a single option.

[Rendered](https://github.com/radicle-dev/radicle-bins/blob/3beb7c85778222a99f5e1ec3b10e474f520ac749/seed/README.md).

Related to: https://github.com/radicle-dev/radicle-docs/pull/13#discussion_r521247216.