### PR TITLE
seed: Amend README to refer to keyutil

### DIFF
--- a/seed/README.md
+++ b/seed/README.md
@@ -29,8 +29,8 @@ To see the seed dashboard, point your browser to http://127.0.0.1:8888.
                       [--description <description>] [--public-addr <public-addr>]
                       [<command>] [<args>]
 
-    To run the seed node, a PKCS8 encoded secret key **must always** be
-    provided in STDIN.
+    To run the seed node, a secret key in the format produced by
+    `radicle-keyutil` **must always** be provided in STDIN.
 
     Options:
       --peer-listen     listen on the following address for peer connections


### PR DESCRIPTION
It's not technically correct that the key is PKCS8 encoded (although that might
not have been the worst idea). Let's just say it's in the format
`radicle-keyutil` outputs.
