### PR TITLE
fix(ui): update stats on changes

### DIFF
--- a/seed/ui/src/App.svelte
+++ b/seed/ui/src/App.svelte
@@ -35,7 +35,7 @@
 </style>
 
 <div class="container">
-  <Header seed={$seed} />
+  <Header seed={$seed} projects={$projects} online={$online} />
   <main>
     <h3>Projects</h3>
     {#each $projects as project}

--- a/seed/ui/src/Components/Header.svelte
+++ b/seed/ui/src/Components/Header.svelte
@@ -1,6 +1,8 @@
 <script>
   import Copyable from "./Copyable.svelte";
   export let seed = null;
+  export let projects = null;
+  export let online = null;
 
   $: seedId = seed.publicAddr
     ? `${seed.peerId}@${seed.publicAddr}`
@@ -51,10 +53,10 @@
   {/if}
 </div>
 <div class="stat">
-  <h2>{seed.peers}</h2>
+  <h2>{online ? online.length : 0}</h2>
   <h5>connected<br />peers</h5>
 </div>
 <div class="stat">
-  <h2>{seed.projects}</h2>
+  <h2>{projects ? projects.length : 0}</h2>
   <h5>seeded<br />projects</h5>
 </div>


### PR DESCRIPTION
The `snapshot` that set the stats is only sent on app start. Since all events trigger either a projects or peers store update, we can get the stats directly from there.

Closes #37 