### PR TITLE
Warn about compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 Collection of various executables for the [Radicle](https://radicle.xyz) stack.
 
+## Radicle Upstream Compatability
+
+As we are working on this infrastructure there will be some compatability issues
+when it comes to `radicle-bins` and `radicle-upstream` which both rely on `radicle-link`.
+
+If you are on Upstream `< v0.1.10` then use the following commit [`f1462b9`](
+https://github.com/radicle-dev/radicle-bins/commit/f1462b92a06ef65ec4b65201e9801473a41b4ee3).
+
 ## Build
 
 See the [Dockerfile used for CI](./.docker/build/Dockerfile) for any system /


### PR DESCRIPTION
Since the latest `master` on `radicle-bins` is not compatible with the latest releases of Upstream we call this out in the README and point people to the commit that _is_ compatible.