### PR TITLE
Expose advertised address configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,6 +1562,7 @@ dependencies = [
  "chrono",
  "futures",
  "librad",
+ "nonempty",
  "num_cpus",
  "radicle-avatar",
  "radicle-seed",

--- a/seed/Cargo.toml
+++ b/seed/Cargo.toml
@@ -9,6 +9,7 @@ license = "GPL-3.0-or-later"
 argh = "0.1"
 chrono = "0.4"
 futures = "0.3"
+nonempty = "0.6"
 num_cpus = "1"
 tokio = { version = "1.2", features = ["sync"], default-features = false }
 tokio-stream = "0.1"


### PR DESCRIPTION
Allow setting the `--advertised-address` option to send only the
expected public IPs.

Requires https://github.com/radicle-dev/radicle-link/pull/597