### PR TITLE
seed: add option to configure logical network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ dependencies = [
 [[package]]
 name = "librad"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?branch=master#646e3e0b51f5643389bba06906c29771c4bbbe2f"
+source = "git+https://github.com/radicle-dev/radicle-link?branch=master#bd75546db090b3920a881878c665937ec9324209"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1517,7 +1517,7 @@ dependencies = [
 [[package]]
 name = "radicle-git-ext"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?branch=master#646e3e0b51f5643389bba06906c29771c4bbbe2f"
+source = "git+https://github.com/radicle-dev/radicle-link?branch=master#bd75546db090b3920a881878c665937ec9324209"
 dependencies = [
  "git2",
  "minicbor",
@@ -1561,7 +1561,7 @@ dependencies = [
 [[package]]
 name = "radicle-macros"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?branch=master#646e3e0b51f5643389bba06906c29771c4bbbe2f"
+source = "git+https://github.com/radicle-dev/radicle-link?branch=master#bd75546db090b3920a881878c665937ec9324209"
 dependencies = [
  "quote",
  "radicle-git-ext",
@@ -1571,7 +1571,7 @@ dependencies = [
 [[package]]
 name = "radicle-seed"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?branch=master#646e3e0b51f5643389bba06906c29771c4bbbe2f"
+source = "git+https://github.com/radicle-dev/radicle-link?branch=master#bd75546db090b3920a881878c665937ec9324209"
 dependencies = [
  "async-trait",
  "futures",
@@ -1606,7 +1606,7 @@ dependencies = [
 [[package]]
 name = "radicle-std-ext"
 version = "0.1.0"
-source = "git+https://github.com/radicle-dev/radicle-link?branch=master#646e3e0b51f5643389bba06906c29771c4bbbe2f"
+source = "git+https://github.com/radicle-dev/radicle-link?branch=master#bd75546db090b3920a881878c665937ec9324209"
 
 [[package]]
 name = "rand"

--- a/seed/src/main.rs
+++ b/seed/src/main.rs
@@ -72,6 +72,12 @@ pub struct Options {
     #[argh(subcommand)]
     pub track: Option<Track>,
 
+    /// join this radicle link network by name.
+    ///
+    /// Leave empty to join the mainnet.
+    #[argh(option, default = "Network::Main")]
+    pub network: Network,
+
     /// listen on the following address for peer connections
     #[argh(option)]
     pub peer_listen: Option<net::SocketAddr>,
@@ -230,7 +236,7 @@ async fn main() {
                 .advertised_address
                 .map(|x| NonEmpty::from_vec(parse_address_list(x)).unwrap()),
             membership,
-            network: Network::default(),
+            network: opts.network,
             replication: replication::Config::default(),
         },
         storage,


### PR DESCRIPTION
Note that this updates radicle-link source dependencies to the latest
master.

Depends-on: radicle-dev/radicle-link@bbde607826a7fb5c6606878c738578b971603cc6
Signed-off-by: Kim Altintop <kim@monadic.xyz>