### PR TITLE
seed: allow fine-grained log level control via RUST_LOG

### DIFF
--- a/seed/src/main.rs
+++ b/seed/src/main.rs
@@ -22,7 +22,7 @@ use std::{
 };
 
 use nonempty::NonEmpty;
-use tracing_subscriber::FmtSubscriber;
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 use librad::{
     git::{replication, Urn},
@@ -184,7 +184,9 @@ fn parse_address_list(option: String) -> Vec<SocketAddr> {
 #[tokio::main]
 async fn main() {
     let opts = Options::from_env();
-    let subscriber = FmtSubscriber::builder().with_max_level(opts.log).finish();
+    let subscriber = FmtSubscriber::builder()
+        .with_env_filter(EnvFilter::from_default_env().add_directive(opts.log.into()))
+        .finish();
 
     tracing::subscriber::set_global_default(subscriber)
         .expect("setting tracing subscriber should succeed");


### PR DESCRIPTION
The EnvFilter from the tracing-subscriber crate allows very fine grained
control over log verbosity, down to matching field values of spans. We
thus re-interpret the `--log` option as merely the base log level, which
can be overriden by RUST_LOG (as undocumented behaviour).

Signed-off-by: Kim Altintop <kim@monadic.xyz>