### PR TITLE
Accept seed secret key from a file

### DIFF
--- a/seed/src/main.rs
+++ b/seed/src/main.rs
@@ -44,14 +44,6 @@ use radicle_seed_node as seed;
 
 use argh::FromArgs;
 
-#[derive(FromArgs)]
-#[argh(
-    subcommand,
-    name = "track-everything",
-    description = "Track everything"
-)]
-pub struct TrackEverything {}
-
 /// A set of peers to track
 #[derive(FromArgs)]
 #[argh(subcommand, name = "track-peers")]
@@ -73,7 +65,6 @@ pub struct TrackUrns {
 #[derive(FromArgs)]
 #[argh(subcommand)]
 pub enum Subcommand {
-    TrackEverything(TrackEverything),
     TrackUrns(TrackUrns),
     TrackPeers(TrackPeers),
 }
@@ -83,7 +74,7 @@ pub enum Subcommand {
 pub struct Options {
     /// track the specified peer only
     #[argh(subcommand)]
-    pub track: Subcommand,
+    pub track: Option<Subcommand>,
 
     /// join this radicle link network by name.
     ///
@@ -275,13 +266,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         bootstrap: opts.bootstrap.map_or_else(Vec::new, parse_peer_list),
         limits: Default::default(),
         mode: match opts.track {
-            Subcommand::TrackPeers(TrackPeers { peers, .. }) => {
+            Some(Subcommand::TrackPeers(TrackPeers { peers, .. })) => {
                 Mode::TrackPeers(peers.into_iter().collect())
             },
-            Subcommand::TrackUrns(TrackUrns { urns, .. }) => {
+            Some(Subcommand::TrackUrns(TrackUrns { urns, .. })) => {
                 Mode::TrackUrns(urns.into_iter().collect())
             },
-            Subcommand::TrackEverything(_) => Mode::TrackEverything,
+            None => Mode::TrackEverything,
         },
     };
     let peer_config = peer::Config {

--- a/seed/src/main.rs
+++ b/seed/src/main.rs
@@ -64,7 +64,7 @@ pub struct TrackUrns {
 
 #[derive(FromArgs)]
 #[argh(subcommand)]
-pub enum Subcommand {
+pub enum Track {
     TrackUrns(TrackUrns),
     TrackPeers(TrackPeers),
 }
@@ -74,7 +74,7 @@ pub enum Subcommand {
 pub struct Options {
     /// track the specified peer only
     #[argh(subcommand)]
-    pub track: Option<Subcommand>,
+    pub track: Option<Track>,
 
     /// join this radicle link network by name.
     ///
@@ -156,7 +156,8 @@ pub struct Options {
     #[argh(option, default = "membership::Params::default().max_passive")]
     pub membership_max_passive: usize,
 
-    #[argh(option, description = "path to the secret key file")]
+    /// path to the secret key file
+    #[argh(option)]
     pub secret_key: Option<PathBuf>,
 }
 
@@ -266,10 +267,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         bootstrap: opts.bootstrap.map_or_else(Vec::new, parse_peer_list),
         limits: Default::default(),
         mode: match opts.track {
-            Some(Subcommand::TrackPeers(TrackPeers { peers, .. })) => {
+            Some(Track::TrackPeers(TrackPeers { peers, .. })) => {
                 Mode::TrackPeers(peers.into_iter().collect())
             },
-            Some(Subcommand::TrackUrns(TrackUrns { urns, .. })) => {
+            Some(Track::TrackUrns(TrackUrns { urns, .. })) => {
                 Mode::TrackUrns(urns.into_iter().collect())
             },
             None => Mode::TrackEverything,

--- a/seed/src/main.rs
+++ b/seed/src/main.rs
@@ -52,7 +52,7 @@ use argh::FromArgs;
 )]
 pub struct TrackEverything {
     #[argh(positional)]
-    secret_key_file_path: Option<String>,
+    secret_key_file_path: String,
 }
 
 /// A set of peers to track
@@ -64,7 +64,7 @@ pub struct TrackPeers {
     peers: Vec<PeerId>,
 
     #[argh(positional)]
-    secret_key_file_path: Option<String>,
+    secret_key_file_path: String,
 }
 
 /// A set of URNs to track
@@ -76,7 +76,7 @@ pub struct TrackUrns {
     urns: Vec<Urn>,
 
     #[argh(positional)]
-    secret_key_file_path: Option<String>,
+    secret_key_file_path: String,
 }
 
 #[derive(FromArgs)]
@@ -247,14 +247,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }) => secret_key_file_path,
     };
 
-    let secret_key: Vec<u8> = if let Some(secret_key_file_path) = secret_key_file_path {
+    let secret_key: Vec<u8> = if secret_key_file_path == "-" {
         let mut secret_key: Vec<u8> = Default::default();
-        let mut file = File::open(secret_key_file_path)?;
-        file.read_to_end(&mut secret_key)?;
+        std::io::stdin().read_to_end(&mut secret_key)?;
         secret_key
     } else {
         let mut secret_key: Vec<u8> = Default::default();
-        std::io::stdin().read_to_end(&mut secret_key)?;
+        let mut file = File::open(secret_key_file_path)?;
+        file.read_to_end(&mut secret_key)?;
         secret_key
     };
 


### PR DESCRIPTION
What: Adds the ability to pass the seed secret key as a regular file (before this, it was possible only via stdin)

Why: For deployment purposes, it's much more convenient to accept the key from a file as it doesn't require an additional shell process that's not available in ["distroless" minimalistic Docker images](https://github.com/GoogleContainerTools/distroless/blob/main/examples/rust/Dockerfile)

Compat:
 * ~~**!Requires small changes from seed node operators!**~~
 * ~~`cargo run -p radicle-seed-node --release -- [...] < ~/.radicle-seed/secret.key` now becomes either~~

~~`cargo run -p radicle-seed-node --release -- [...] track-everything < ~/.radicle-seed/secret.key`~~

~~or without the redirection:~~

~~`cargo run -p radicle-seed-node --release -- [...] track-everything ~/.radicle-seed/secret.key` depending on what's more convenient.~~