### PR TITLE
Output logs in GCP-compatible format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "aead"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +345,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "serde",
  "time 0.1.43",
  "winapi 0.3.9",
 ]
@@ -1913,6 +1924,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "tracing-stackdriver",
  "tracing-subscriber",
  "warp",
 ]
@@ -2707,6 +2719,23 @@ checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
 dependencies = [
  "serde",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-stackdriver"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a7fc78ad2f400f707e1f42926490d9fc671ac0a71bc0d74f8a0ced836cb66e"
+dependencies = [
+ "Inflector",
+ "chrono",
+ "futures",
+ "serde",
+ "serde_json",
+ "tracing-core",
+ "tracing-futures",
+ "tracing-serde",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/seed/Cargo.toml
+++ b/seed/Cargo.toml
@@ -18,7 +18,12 @@ tracing-subscriber = "0.2"
 warp = { version = "0.3", default-features = false }
 serde_json = "1"
 serde = "1"
+tracing-stackdriver = { version = "0.1.0", optional = true }
 
 librad = "0"
 radicle-avatar = "0"
 radicle-seed = "0"
+
+[features]
+default = []
+gcp = ["tracing-stackdriver"]


### PR DESCRIPTION
This should allow for setting simple alerts, filtering by log level, etc.