### PR TITLE
Use patched version of the gcp logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3198,14 +3198,14 @@ dependencies = [
 [[package]]
 name = "tracing-stackdriver"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a7fc78ad2f400f707e1f42926490d9fc671ac0a71bc0d74f8a0ced836cb66e"
+source = "git+https://github.com/radicle-dev/tracing-stackdriver.git#f161dad5e37249b14c35df78602471679747fe48"
 dependencies = [
  "Inflector",
  "chrono",
  "futures",
  "serde",
  "serde_json",
+ "thiserror",
  "tracing-core",
  "tracing-futures",
  "tracing-serde",

--- a/seed/Cargo.toml
+++ b/seed/Cargo.toml
@@ -18,7 +18,7 @@ tracing-subscriber = "0.2"
 warp = { version = "0.3", default-features = false }
 serde_json = "1"
 serde = "1"
-tracing-stackdriver = { version = "0.1.0", optional = true }
+tracing-stackdriver = { git = "https://github.com/radicle-dev/tracing-stackdriver.git", optional = true }
 
 librad = "0"
 radicle-avatar = "0"

--- a/seed/src/main.rs
+++ b/seed/src/main.rs
@@ -270,7 +270,7 @@ fn init_logger(opts: &Options) {
         LogFmt::Gcp => {
             use tracing_stackdriver::Stackdriver;
             use tracing_subscriber::{layer::SubscriberExt, Registry};
-            let stackdriver = Stackdriver::with_writer(std::io::stderr); // writes to std::io::Stderr
+            let stackdriver = Stackdriver::default();
             let subscriber = Registry::default().with(stackdriver);
             tracing::subscriber::set_global_default(subscriber)
                 .expect("Could not set up global logger");


### PR DESCRIPTION
A patch there adds a missing newline at the end of each log entry.

Signed-off-by: Adam Szkoda <adaszko@gmail.com>